### PR TITLE
google login delegates post-login redirect to client

### DIFF
--- a/src/api/routes/googleLogin.js
+++ b/src/api/routes/googleLogin.js
@@ -22,7 +22,8 @@ express.get('/api/completeGoogleLogin', routeHandler(async (request, response) =
 
     setLoginCookie({response, loginId: result.loginId});
 
-    response.redirect(301, '/followers');
+    // Redirecting to login lets the client figure the proper route itself based on user type
+    response.redirect(301, '/login');
 }, {
     enforceLogin: false
 }));


### PR DESCRIPTION
Follower users need to be redirected after login to a page different from that of leader users.

__Note__: I couldn't test it in my dev environment. There seems to be no reason this shouldn't work, but we'll have to test it immediately after deployment.