### PR TITLE
allow resonators without attachments by changing the JOIN type

### DIFF
--- a/src/api/routes/followers/queries.js
+++ b/src/api/routes/followers/queries.js
@@ -40,6 +40,7 @@ export const fetchFollowerSentResonators = async (follower, pageNum) => ({
                         model: resonator_attachments,
                         where: { media_kind: "picture", visible: 1 },
                         order: [["created_at", "DESC"]],
+                        required: false
                     },
                 ],
             },
@@ -89,6 +90,7 @@ export const fetchSentResonator = async (follower, sentResonatorId) =>
                         model: resonator_attachments,
                         where: { media_kind: "picture", visible: 1 },
                         order: [["created_at", "DESC"]],
+                        required: false
                     },
                 ],
             },


### PR DESCRIPTION
Putting a `where` in an `include` turns the eager load into an inner join, which means if there are no associated entries there will be no results.
Since we allow resonators with no pictures, I've added a `requried: false` so the query still uses an outer join.
This fixes the issue that sent resonators with no pictures could not be viewed in the follower application.