### PR TITLE
Feature/advanced schedule

### DIFF
--- a/src/application/dto/index.js
+++ b/src/application/dto/index.js
@@ -66,6 +66,7 @@ export function toResonator(resonator) {
                        'interaction_type',
                        'selected_questionnaire',
                        'questionnaire_details',
+                       'interval',
                        'createdAt',
                        'updatedAt'
                       );

--- a/src/application/resonators.js
+++ b/src/application/resonators.js
@@ -41,7 +41,7 @@ export async function updateResonator(resonator_id, updatedFields) {
 
     updatePermittedFields(resonator, updatedFields, [
         'title', 'link', 'description', 'content', 'repeat_days', 'disable_copy_to_leader', 'pop_email', 'pop_time',
-        'one_off', 'ttl_policy', 'interaction_type', 'selected_questionnaire', 'questionnaire_details'
+        'one_off', 'ttl_policy', 'interaction_type', 'selected_questionnaire', 'questionnaire_details', 'interval'
     ]);
 
     await getUow().commit();

--- a/src/db/dbToDomain.js
+++ b/src/db/dbToDomain.js
@@ -78,6 +78,7 @@ export function toResonator(r) {
         interaction_type: r.get('interaction_type'),
         selected_questionnaire: r.get('selected_questionnaire'),
         questionnaire_details: r.get('questionnaire_details'),
+        interval: r.get('interval'),
         items: resonator_attachments,
         questions: resonator_questions,
         createdAt: r.get('createdAt'),

--- a/src/db/sequelize/migrations/20201002130848-add-resonator-schedule-interval.js
+++ b/src/db/sequelize/migrations/20201002130848-add-resonator-schedule-interval.js
@@ -1,0 +1,11 @@
+"use strict";
+
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        return await queryInterface.addColumn("resonators", "interval", { type: Sequelize.INTEGER });
+    },
+
+    down: async (queryInterface, Sequelize) => {
+        return await queryInterface.removeColumn("resonators", "interval");
+    },
+};

--- a/src/db/sequelize/models/resonators.js
+++ b/src/db/sequelize/models/resonators.js
@@ -24,6 +24,7 @@ module.exports = (sequelize, DataTypes) => {
             interaction_type: DataTypes.INTEGER,
             selected_questionnaire: DataTypes.STRING,
             questionnaire_details: DataTypes.STRING,
+            interval: DataTypes.INTEGER,
         },
         { underscored: true }
     );

--- a/src/domain/entities/resonator.js
+++ b/src/domain/entities/resonator.js
@@ -25,6 +25,7 @@ export default class Resonator {
         interaction_type,
         selected_questionnaire,
         questionnaire_details,
+        interval,
         items,
         questions,
         createdAt,
@@ -58,6 +59,7 @@ export default class Resonator {
         this.interaction_type = interaction_type;
         this.selected_questionnaire = selected_questionnaire;
         this.questionnaire_details = questionnaire_details;
+        this.interval = interval;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
 

--- a/src/emailScheduler/fetchPendingResonators.js
+++ b/src/emailScheduler/fetchPendingResonators.js
@@ -12,6 +12,7 @@ function buildQuery(timestamp) {
                AND (last_pop_time IS NULL OR date(${timestamp}) > date(coalesce(last_pop_time, '1970-01-01')))
                AND ${timestamp}::timestamp::time >= pop_time::time
                AND position(extract(dow from ${timestamp}::timestamp)::char IN repeat_days) > 0
+               AND (extract(week from ${timestamp}::timestamp) - extract(week from last_pop_time::timestamp))::int % interval = 0
                AND pop_email = TRUE
                AND fu.id IS NOT NULL
                AND lu.id IS NOT NULL

--- a/src/emailScheduler/fetchPendingResonators.js
+++ b/src/emailScheduler/fetchPendingResonators.js
@@ -12,7 +12,7 @@ function buildQuery(timestamp) {
                AND (last_pop_time IS NULL OR date(${timestamp}) > date(coalesce(last_pop_time, '1970-01-01')))
                AND ${timestamp}::timestamp::time >= pop_time::time
                AND position(extract(dow from ${timestamp}::timestamp)::char IN repeat_days) > 0
-               AND (extract(week from ${timestamp}::timestamp) - extract(week from last_pop_time::timestamp))::int % interval = 0
+               AND (last_pop_time IS NULL OR ((extract(week from ${timestamp}::timestamp) - extract(week from last_pop_time::timestamp))::int % interval = 0))
                AND pop_email = TRUE
                AND fu.id IS NOT NULL
                AND lu.id IS NOT NULL


### PR DESCRIPTION
Added the ability to change the number of weeks between send times in a resonator's schedule.

Notes:
- The new field is generically called "interval" cause we will want to add support for "every X days" schedule in the future
- After the deployment we must run the following SQL query: `UPDATE resonators SET interval = 1;`